### PR TITLE
Fix address hexification in deploy script

### DIFF
--- a/app/scripts/deploy_service.js
+++ b/app/scripts/deploy_service.js
@@ -5,8 +5,7 @@ oasis.workspace.Quickstart.deploy({
   header: {confidential: false},
 })
   .then(res => {
-    let addrHex = Buffer.from(res.address).toString('hex');
-    console.log(`    ${chalk.green('Deployed')} Quickstart at 0x${addrHex}`);
+    console.log(`    ${chalk.green('Deployed')} Quickstart at ${res.address.hex}`);
   })
   .catch(err => {
     console.error(chalk.red('error'), err);


### PR DESCRIPTION
Get this error when running `node app/scripts/deploy_service.js`
```
error TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type object
```
. This is because `Buffer` does not accept an object like this
```
Address {
  _bytes:
   Uint8Array [
     60,
     181,
     248,
     243,
     25,
     ...
     ] }
```
. Fixed by calling `.toString()` on `Address`.